### PR TITLE
Fix the function of not creating a contract in the call contract

### DIFF
--- a/src/rpc/eth.rs
+++ b/src/rpc/eth.rs
@@ -94,7 +94,7 @@ impl EthApi for EthApiImpl {
         let resp = self
             .state
             .evm
-            .call_contract(MAIN_BRANCH_NAME, req, bn)
+            .contract_handle(MAIN_BRANCH_NAME, req, bn)
             .map_err(|e| {
                 error::new_jsonrpc_error(
                     "call contract failed",
@@ -642,7 +642,7 @@ impl EthApi for EthApiImpl {
         let resp = self
             .state
             .evm
-            .call_contract(MAIN_BRANCH_NAME, req, bn)
+            .contract_handle(MAIN_BRANCH_NAME, req, bn)
             .map_err(|e| {
                 error::new_jsonrpc_error(
                     "call contract failed",


### PR DESCRIPTION
Modify `call_contract` to `contract_handle`, because there is not only `call` but also `create`

The fix is to resolve the issue of incorrect estimated fees when deploying contracts