### PR TITLE
Implement the interface to get the git version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,4 +92,4 @@ overflow-checks = false
 
 [build-dependencies]
 vergen = "6"
-ruc = { version = "1.0.7", features = ["cmd"] }
+ruc = "1.0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://github.com/Overealityio/OVR"
 repository = "https://github.com/Overealityio/OVR"
 keywords = ["blockchain", "defi", "state"]
 license = "MIT"
+build = "build.rs"
 
 [[bin]]
 name = "ovr"
@@ -88,3 +89,7 @@ overflow-checks = false
 codegen-units = 1
 incremental = false
 overflow-checks = false
+
+[build-dependencies]
+vergen = "6"
+ruc = { version = "1.0.7", features = ["cmd"] }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+use ruc::*;
+use vergen::{vergen, Config};
+
+fn main() -> Result<()> {
+    // Generate the default 'cargo:' instruction output
+    vergen(Config::default()).map_err(|e| eg!(e.to_string()))
+}

--- a/src/rpc/net.rs
+++ b/src/rpc/net.rs
@@ -5,7 +5,8 @@ pub struct NetApiImpl {}
 
 impl NetApi for NetApiImpl {
     fn version(&self) -> BoxFuture<Result<String>> {
-        Box::pin(async { Ok(0.to_string()) })
+        let git_version = env!("VERGEN_GIT_SHA");
+        Box::pin(async { Ok(git_version.to_string()) })
     }
 
     fn peer_count(&self) -> BoxFuture<Result<PeerCount>> {

--- a/src/rpc/net.rs
+++ b/src/rpc/net.rs
@@ -1,12 +1,34 @@
+use crate::rpc::error::new_jsonrpc_error;
 use jsonrpc_core::{BoxFuture, Result};
+use serde_json::Value;
 use web3_rpc_core::{types::PeerCount, NetApi};
+use serde::{Deserialize, Serialize};
 
 pub struct NetApiImpl {}
 
+#[derive(Deserialize, Serialize)]
+struct VersionInfo<'a> {
+    git_commit: &'a str,
+    git_semver: &'a str,
+    rustc_commit: &'a str,
+    rustc_semver: &'a str,
+}
+
 impl NetApi for NetApiImpl {
-    fn version(&self) -> BoxFuture<Result<String>> {
-        let git_version = env!("VERGEN_GIT_SHA");
-        Box::pin(async { Ok(git_version.to_string()) })
+    fn version(&self) -> BoxFuture<Result<Value>> {
+        let vi = VersionInfo {
+            git_commit: env!("VERGEN_GIT_SHA"),
+            git_semver: env!("VERGEN_GIT_SEMVER"),
+            rustc_commit: env!("VERGEN_RUSTC_COMMIT_HASH"),
+            rustc_semver: env!("VERGEN_RUSTC_SEMVER"),
+        };
+
+        Box::pin(async move {
+            match serde_json::to_value(&vi) {
+                Ok(json) => Ok(json),
+                Err(e) => Err(new_jsonrpc_error(e.to_string().as_str(), Value::Null)),
+            }
+        })
     }
 
     fn peer_count(&self) -> BoxFuture<Result<PeerCount>> {


### PR DESCRIPTION
Implement the interface `net_version` to get the git version

The version information returned contains, git commit hash`(git_commit)`, git semver`(git_semver)`, rustc commit hash`(rustc_commit)`, rustc semver`(rustc_semver)`

```jsonc

req

{
    "jsonrpc":"2.0",
    "method":"net_version",
    "params":[],
    "id":1
}

resp

{
  "jsonrpc": "2.0",
  "result": {
    "git_commit": "99abf23d26f2b1d66c2c6b90ab65f9cfe9e8d343",
    "git_semver": "0.0.3-release-25-g99abf23",
    "rustc_commit": "f0c4da49983aa699f715caf681e3154b445fb60b",
    "rustc_semver": "1.61.0-nightly"
  },
  "id": 1
}


```
![image](https://user-images.githubusercontent.com/31642966/157829600-1e54b7ff-0619-41ec-bb8a-836565df6e7d.png)
