### PR TITLE
Fix the bug of interaction with blockscout

### DIFF
--- a/src/ethvm/tx/mod.rs
+++ b/src/ethvm/tx/mod.rs
@@ -462,10 +462,14 @@ impl ExecRet {
         }
     }
 
-    pub fn gen_logs<'a>(&'a self, tx_hash: HashValueRef<'a>) -> Vec<LedgerLog> {
+    pub fn gen_logs<'a>(
+        &'a self,
+        tx_hash: HashValueRef<'a>,
+        tx_index: u64,
+    ) -> Vec<LedgerLog> {
         let mut v = Vec::new();
-        for l in self.logs.iter() {
-            v.push(LedgerLog::new_from_eth_log_and_tx_hash(l, tx_hash));
+        for (index, l) in self.logs.iter().enumerate() {
+            v.push(LedgerLog::new(l, tx_hash, index, tx_index));
         }
         v
     }


### PR DESCRIPTION
1. 修复了`eth_getBlockByNumber`中因为字段`hash`和`number`为空导致blockscout会崩溃的问题
2. 修复了`eth_getTransactionReceipt`中因为字段`status_code`为空导致的状态显示不正确的问题
3. 修复了部署合约后blockscout插入数据失败的问题,原因是结构体`receipt`中的字段`logs`中没有正确赋值某些字段导致

测试结果:

![1edbbc242d7c16eb369bdf1da38812b](https://user-images.githubusercontent.com/31642966/158347472-57ac5d43-a14b-46c1-bd23-4c5d6f7d0e40.png)
